### PR TITLE
Explicit boolean check on single module check

### DIFF
--- a/kansa.ps1
+++ b/kansa.ps1
@@ -345,7 +345,7 @@ Param(
     # Need to maintain the order for "order of volatility"
     $ModuleHash = New-Object System.Collections.Specialized.OrderedDictionary
 
-    if (!(ls $ModuleScript -ErrorAction SilentlyContinue).PSIsContainer) {
+    if ((ls $ModuleScript -ErrorAction SilentlyContinue).PSIsContainer -eq $False) {
         # User may have provided full path to a .ps1 module, which is how you run a single module explicitly
         $ModuleHash.Add((ls $ModuleScript), $ModuleArgs)
 


### PR DESCRIPTION
I tried running Kansa on a Windows XP SP3 w/ PowerShell 2.0 and couldn't get past this check. Using an explicit boolean comparison made it work. I'm not sure if this was a language feature that changed. I wanted to use Kansa to help evaluate malware indicators of compromise on known evil code.
