### PR TITLE
Get-Products replaced with faster and better version

### DIFF
--- a/Modules/Config/Get-Products.ps1
+++ b/Modules/Config/Get-Products.ps1
@@ -1,10 +1,10 @@
 ﻿<#
 .SYNOPSIS
 Get-Products.ps1 returns data about products that were installed via 
-the Windows installer.
+the installer.
 .NOTES
 The next line is needed by Kansa.ps1 to determine how the output from
 this script should be handled.
-OUTPUT tsv
+OUTPUT csv
 #>
-Get-WmiObject Win32_Product
+Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate, InstallSource


### PR DESCRIPTION
WMI is too slow, it is showing only MSI installed packages and it is dangerous to use because it runs consistency check and package repair when you query it. Don't use it.
http://blogs.technet.com/b/heyscriptingguy/archive/2011/11/13/use-powershell-to-quickly-find-installed-software.aspx
