### PR TITLE
fix autoruns output loss on convert to csv in PS

### DIFF
--- a/Modules/ASEP/Get-Autorunsc.ps1
+++ b/Modules/ASEP/Get-Autorunsc.ps1
@@ -35,7 +35,7 @@ time stamps.
 #>
 
 if (Test-Path "$env:SystemRoot\Autorunsc.exe") {
-    & $env:SystemRoot\Autorunsc.exe /accepteula -a * -c -h -s '*' 2> $null | ConvertFrom-Csv | ForEach-Object {
+    & $env:SystemRoot\Autorunsc.exe /accepteula -a * -c -h -s '*' -nobanner 2> $null | ConvertFrom-Csv | ForEach-Object {
         $_
     }
 } else {

--- a/Modules/ASEP/Get-AutorunscDeep.ps1
+++ b/Modules/ASEP/Get-AutorunscDeep.ps1
@@ -126,7 +126,7 @@ Param(
 if (Test-Path "$env:SystemRoot\Autorunsc.exe") {
     # This regex matches all of the path types I've encountered, but there may be some it misses, if you find some, please send a sample to kansa@trustedsignal.com
     $fileRegex = New-Object System.Text.RegularExpressions.Regex "(([a-zA-Z]:|\\\\\w[ \w\.]*)(\\\w[- \w\.\\\{\}]*|\\%[ \w\.]+%+)+|%[ \w\.]+%(\\\w[ \w\.]*|\\%[ \w\.]+%+)*)"
-    & $env:SystemRoot\Autorunsc.exe /accepteula -a * -c -h -s '*' 2> $null | ConvertFrom-Csv | ForEach-Object {
+    & $env:SystemRoot\Autorunsc.exe /accepteula -a * -c -h -s '*' -nobanner 2> $null | ConvertFrom-Csv | ForEach-Object {
         $_ | Add-Member NoteProperty ScriptMD5 $null
         $_ | Add-Member NoteProperty ScriptModTimeUTC $null
         $_ | Add-Member NoteProperty ShannonEntropy $null

--- a/Modules/ASEP/Get-SchedTasks.ps1
+++ b/Modules/ASEP/Get-SchedTasks.ps1
@@ -1,0 +1,9 @@
+<#
+.SYNOPSIS
+Get-ShedTasks.ps1 returns information about all Windows Scheduled Tasks.
+.NOTES
+The following line is required by Kansa.ps1, which uses it to determine
+how to handle the output from this script.
+OUTPUT tsv
+#>
+Get-ScheduledTask

--- a/Modules/ASEP/Get-SchedTasksInfo
+++ b/Modules/ASEP/Get-SchedTasksInfo
@@ -1,0 +1,9 @@
+<#
+.SYNOPSIS
+Get-ShedTasksInfo.ps1 returns operational information about all Windows Scheduled Tasks.
+.NOTES
+The following line is required by Kansa.ps1, which uses it to determine
+how to handle the output from this script.
+OUTPUT tsv
+#>
+Get-ScheduledTask | Get-ScheduledTaskInfo

--- a/Modules/ASEP/Get-SchedTasksInfo
+++ b/Modules/ASEP/Get-SchedTasksInfo
@@ -1,9 +1,0 @@
-<#
-.SYNOPSIS
-Get-ShedTasksInfo.ps1 returns operational information about all Windows Scheduled Tasks.
-.NOTES
-The following line is required by Kansa.ps1, which uses it to determine
-how to handle the output from this script.
-OUTPUT tsv
-#>
-Get-ScheduledTask | Get-ScheduledTaskInfo

--- a/Modules/ASEP/Get-SchedTasksInfo.ps1
+++ b/Modules/ASEP/Get-SchedTasksInfo.ps1
@@ -1,0 +1,9 @@
+<#
+.SYNOPSIS
+Get-ShedTasks.ps1 returns operational information about all Windows Scheduled Tasks.
+.NOTES
+The following line is required by Kansa.ps1, which uses it to determine
+how to handle the output from this script.
+OUTPUT tsv
+#>
+Get-ScheduledTask | Get-ScheduledTaskInfo

--- a/Modules/Disk/Get-FileHashes.ps1
+++ b/Modules/Disk/Get-FileHashes.ps1
@@ -95,7 +95,7 @@ workflow Get-HashesWorkflow {
 	$hashList = @()
 	
 	$Files = (
-		Get-ChildItem -Force -Path $basePath -Recurse -Force -ErrorAction SilentlyContinue | 
+		Get-ChildItem -Force -Path $basePath -Recurse -ErrorAction SilentlyContinue | 
 		? -FilterScript { 
 			($_.Length -ge $MinB -and $_.Length -le $_.Length) -and 
 			($_.Extension -match $extRegex) 
@@ -163,7 +163,7 @@ function Get-Hashes {
 	$hashList = @()
 	
 	$Files = (
-		Get-ChildItem -Force -Path $basePath -Recurse -Force -ErrorAction SilentlyContinue | 
+		Get-ChildItem -Force -Path $basePath -Recurse -ErrorAction SilentlyContinue | 
 		? -FilterScript { 
 			($_.Length -ge $MinB -and $_.Length -le $_.Length) -and 
 			($_.Extension -match $extRegex) 

--- a/Modules/Modules.conf
+++ b/Modules/Modules.conf
@@ -41,6 +41,8 @@ ASEP\Get-WMIEvtFilter.ps1
 ASEP\Get-WMIFltConBind.ps1
 ASEP\Get-WMIEvtConsumer.ps1
 ASEP\Get-PSProfiles.ps1
+ASEP\Get-SchedTasks.ps1
+ASEP\Get-SchedTasksInfo.ps1
 # Disk\Get-TempDirListing.ps1
 Disk\Get-File.ps1 C:\Windows\WindowsUpdate.log
 # Disk\Get-DiskUsage.ps1 C:\Users


### PR DESCRIPTION
Just started testing Kansa today.  This problem may be due to a new version of autorunsc, maybe?  I added the "-nobanner" option to autorunsc in both autorunsc modules to fix the loss of the output when PS converted it to csv.