### PR TITLE
Update Kansa to add additional output options

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -1,0 +1,17 @@
+# Use this file to configure the logging destination of your choice.
+
+## Splunk
+# The next few lines define the Splunk instance information
+# Remember to configure the HEC on Splunk prior to use
+# https://docs.splunk.com/Documentation/Splunk/7.2.3/Data/UsetheHTTPEventCollector#Configure_HTTP_Event_Collector_on_Splunk_Enterprise
+# 
+# Also, don't encapsulate anything in quotation marks. 
+# If you do, it will break the parsing of configuation parameters, and nothing will work.
+#
+splHECToken=q2v9f4c6-5b0c-1m9p-21l8-q17c0101709a
+splServerName=monstro
+splServerPort=8088
+
+## Graylog
+glServerName=monstro
+glServerPort=12201


### PR DESCRIPTION
I always thought that manually analyzing csv or json files (or even using command line tools for analysis) was a pain, and that Kansa could be massively improved by adding the ability to send output to Splunk. So, I added the ability output to Splunk and GrayLog (sorry, no ELK endpoint for now... maybe later).

By adding Splunk and GrayLog as output options, Kansa output can now be analyzed right alongside other centrally logged data - awesome!