### PR TITLE
Fixed autorun module not working anymore

### DIFF
--- a/Modules/ASEP/Get-Autorunsc.ps1
+++ b/Modules/ASEP/Get-Autorunsc.ps1
@@ -35,7 +35,7 @@ time stamps.
 #>
 
 if (Test-Path "$env:SystemRoot\Autorunsc.exe") {
-    & $env:SystemRoot\Autorunsc.exe /accepteula -a * -c -h -s '*' 2> $null | ConvertFrom-Csv | ForEach-Object {
+    & $env:SystemRoot\Autorunsc.exe /accepteula -a * -c -h -s '*' -nobanner 2> $null | ConvertFrom-Csv | ForEach-Object {
         $_
     }
 } else {


### PR DESCRIPTION
When using the autorun module to get the `autorunsc.exe` output, the file only contains a header but no content is there.