### PR TITLE
Logparser switch deprecated

### DIFF
--- a/Analysis/config/Get-LocalAdminStack.ps1
+++ b/Analysis/config/Get-LocalAdminStack.ps1
@@ -17,14 +17,14 @@ if (Get-Command logparser.exe) {
         COUNT(Account) as ct,
         Account
     FROM
-        *LocalAdmins.tsv
+        *LocalAdmins.csv
     GROUP BY
         Account
     ORDER BY
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -dtlines:0 -fixedsep:on -rtp:-1 "$lpquery"
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 "$lpquery"
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)


### PR DESCRIPTION
The file was looking for a .tsv file but only .csv existed and the logparser switch no longer exists.