### PR TITLE
Fix logparser deprecated switch

### DIFF
--- a/Analysis/asep/Get-ASEPImagePathLaunchStringMD5UnsignedStack.ps1
+++ b/Analysis/asep/Get-ASEPImagePathLaunchStringMD5UnsignedStack.ps1
@@ -23,7 +23,7 @@ if (Get-Command logparser.exe) {
         MD5,
         Publisher
     FROM
-        *autorunsc.tsv
+        *autorunsc.csv
     WHERE
         Publisher not like '(Verified)%' and
         (ImagePath not like 'File not found%')
@@ -36,7 +36,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -dtlines:0 -fixedsep:on -rtp:-1 "$lpquery"
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 "$lpquery"
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-ASEPImagePathLaunchStringMD5UnsignedTimeStack.ps1
+++ b/Analysis/asep/Get-ASEPImagePathLaunchStringMD5UnsignedTimeStack.ps1
@@ -26,7 +26,7 @@ if (Get-Command logparser.exe) {
         Time,
         Publisher
     FROM
-        *autorunsc.tsv
+        *autorunsc.csv
     WHERE
         ImagePath is not null and
         Publisher not like '(Verified)%' and
@@ -41,7 +41,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser -i:csv -dtlines:0 -fixedsep:on -rtp:-1 "$lpquery"
+    & logparser -i:csv -dtlines:0 -rtp:-1 "$lpquery"
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-ASEPImagePathLaunchStringPublisherStack.ps1
+++ b/Analysis/asep/Get-ASEPImagePathLaunchStringPublisherStack.ps1
@@ -20,7 +20,7 @@ if (Get-Command logparser.exe) {
         LaunchString,
         Publisher
     FROM
-        *autorunsc.tsv
+        *autorunsc.csv
     WHERE
         (ImagePath not like 'File not found%')
     GROUP BY
@@ -31,7 +31,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -dtlines:0 -fixedsep:on -rtp:-1 "$lpquery"
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 "$lpquery"
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-ASEPImagePathLaunchStringStack.ps1
+++ b/Analysis/asep/Get-ASEPImagePathLaunchStringStack.ps1
@@ -19,7 +19,7 @@ if (Get-Command logparser.exe) {
         ImagePath,
         LaunchString
     FROM
-        *autorunsc.tsv
+        *autorunsc.csv
     WHERE
         (ImagePath not like 'File not found%')
     GROUP BY
@@ -29,7 +29,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -dtlines:0 -fixedsep:on -rtp:-1 "$lpquery"
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 "$lpquery"
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-ASEPImagePathLaunchStringUnsignedStack.ps1
+++ b/Analysis/asep/Get-ASEPImagePathLaunchStringUnsignedStack.ps1
@@ -19,7 +19,7 @@ if (Get-Command logparser.exe) {
         ImagePath,
         LaunchString
     FROM
-        *autorunsc.tsv
+        *autorunsc.csv
     WHERE
         Publisher not like '(Verified)%' and
         (ImagePath not like 'File not found%')
@@ -30,7 +30,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -dtlines:0 -fixedsep:on -rtp:-1 "$lpquery"
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 "$lpquery"
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-SvcFailAllStack.ps1
+++ b/Analysis/asep/Get-SvcFailAllStack.ps1
@@ -25,7 +25,7 @@ if (Get-Command logparser.exe) {
         FailAction2,
         FailAction3
     FROM
-        *SvcFail.tsv 
+        *SvcFail.csv 
     GROUP BY
         ServiceName, 
         CmdLine,
@@ -36,7 +36,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -fixedsep:on -dtlines:0 -rtp:-1 $lpquery
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 $lpquery
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-SvcFailCmdLineStack.ps1
+++ b/Analysis/asep/Get-SvcFailCmdLineStack.ps1
@@ -18,14 +18,14 @@ if (Get-Command logparser.exe) {
         COUNT(To_Lowercase(CmdLine)) as ct, 
         To_Lowercase(CmdLine) as CmdLineLC
     FROM
-        *SvcFail.tsv
+        *SvcFail.csv
     GROUP BY
         CmdLineLC
     ORDER BY
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -fixedsep:on -dtlines:0 -rtp:-1 $lpquery
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 $lpquery
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-SvcFailStack.ps1
+++ b/Analysis/asep/Get-SvcFailStack.ps1
@@ -26,7 +26,7 @@ if (Get-Command logparser.exe) {
         FailAction2,
         FailAction3
     FROM
-        *SvcFail.tsv
+        *SvcFail.csv
     WHERE
         CmdLine <> 'customScript.cmd' AND
         CmdLine is not NULL
@@ -40,7 +40,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser -stats:off -i:csv -fixedsep:on -dtlines:0 -rtp:-1 $lpquery
+    & logparser -stats:off -i:csv -dtlines:0 -rtp:-1 $lpquery
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)

--- a/Analysis/asep/Get-SvcTrigStack.ps1
+++ b/Analysis/asep/Get-SvcTrigStack.ps1
@@ -21,7 +21,7 @@ if (Get-Command logparser.exe) {
         Subtype, 
         Data 
     FROM
-        *svctrigs.tsv 
+        *svctrigs.csv 
     GROUP BY
         ServiceName, 
         Action, 
@@ -32,7 +32,7 @@ if (Get-Command logparser.exe) {
         ct ASC
 "@
 
-    & logparser  -stats:off -i:csv -fixedsep:on -dtlines:0 -rtp:-1 $lpquery
+    & logparser  -stats:off -i:csv -dtlines:0 -rtp:-1 $lpquery
 
 } else {
     $ScriptName = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)


### PR DESCRIPTION
The fixedsep switch does not work on the version 2.2 of LogParser regarding on the ASEP Folder.