### PR TITLE
Fix for Issue #213

### DIFF
--- a/kansa.ps1
+++ b/kansa.ps1
@@ -502,14 +502,15 @@ Param(
     # Need to maintain the order for "order of volatility"
     $ModuleHash = New-Object System.Collections.Specialized.OrderedDictionary
 
-    if (!(ls $ModuleScript | Select-Object -ExpandProperty PSIsContainer)) {
-        # User may have provided full path to a .ps1 module, which is how you run a single module explicitly
-        $ModuleHash.Add((ls $ModuleScript), $ModuleArgs)
+    if (Test-Path($ModuleScript)) {
+    	if (!(ls $ModuleScript | Select-Object -ExpandProperty PSIsContainer)) {
+        	# User may have provided full path to a .ps1 module, which is how you run a single module explicitly
+        	$ModuleHash.Add((ls $ModuleScript), $ModuleArgs)
 
-        if (Test-Path($ModuleScript)) {
-            $Module = ls $ModuleScript | Select-Object -ExpandProperty BaseName
-            Write-Verbose "Running module: `n$Module $ModuleArgs"
-            Return $ModuleHash
+        
+            	$Module = ls $ModuleScript | Select-Object -ExpandProperty BaseName
+           	Write-Verbose "Running module: `n$Module $ModuleArgs"
+            	Return $ModuleHash
         }
     }
     $ModConf = $ModulePath + "\" + "Modules.conf"

--- a/kansa.ps1
+++ b/kansa.ps1
@@ -374,7 +374,7 @@ Param(
     [Parameter(Mandatory=$false,Position=21)]
         [String[]]$ElkAlert=@(),
     [Parameter(Mandatory=$false,Position=22)]
-        [int32]$JobTimeout=600,
+        [int32]$JobTimeout=900,
     [Parameter(Mandatory=$false,Position=23)]
         [uint16[]]$ElkPort=@(1337),
     [Parameter(Mandatory=$false,Position=24)]


### PR DESCRIPTION
Move if(testpath($modulescript) on line 509 to line 505 in order catch unforeseen error which arises from a split operation on 498 if a module path contains a space character