### PR TITLE
Fix for #215 + minor additions

### DIFF
--- a/Get-Targets.ps1
+++ b/Get-Targets.ps1
@@ -26,8 +26,8 @@ $real_targets = New-Object System.Collections.ArrayList
 
 #MR edit - $tgt.Name changed to $tgt as Name does not appear to valid attribute from my own testing and this loop results in an empty array
 foreach ($tgt in $targets){
-    if ($tgt.Name -match $HostnameRegex){
-        [void]$real_targets.Add($tgt)
+    if ($tgt.ObjectClass -eq "computer"){
+        [void]$real_targets.Add($tgt.DNSHostName)
     }
 }
 

--- a/kansa.ps1
+++ b/kansa.ps1
@@ -885,8 +885,10 @@ Param(
 
                 # Remove excess properties that we don't need in the module output
                 foreach ($i in $Recpt){
-                    $i.PSObject.Properties.Remove("PSShowComputerName")
+                    if(-not ([string]::IsNullOrEmpty($i))){
+		    $i.PSObject.Properties.Remove("PSShowComputerName")
                     $i.PSObject.Properties.Remove("RunspaceId")
+		    }
                 }
             
                 # Log errors from child jobs, including module and host that failed.
@@ -902,7 +904,7 @@ Param(
                     "ERROR: ${GetlessMod}'s output path length exceeds 260 character limit. Can't write the output to disk for $($ChildJob.Location)." | Add-Content -Encoding $Encoding $ErrorLog
                     Continue
                 }
-
+		try{
                 # save the data
                 switch -Wildcard ($OutputFormat) {
                     "*csv" {
@@ -978,6 +980,7 @@ Param(
                         $Recpt | Export-Csv -NoTypeInformation -Encoding $Encoding $Outfile
                     }
                 }
+		}catch{("Caught:{0}" -f $_)}
             }
 
             # Release memory reserved for Job data since we don't need it any more.


### PR DESCRIPTION
- Check added for null values returned by Child Jobs + Try/catch for switch statement to save results to avoid hard fail of Get-TargetData
- Minor increase in default timeout for jobs to 900 seconds (My testing found it wasn't long enough to allow Get-FileHash.ps1 to complete during more demanding operations)
- Fix to Get-Targets.ps1 - remove $HostNameRegex on line 29 as default value of "*." was resulting in no target devices matching and in turn no target devices being returned by Get-Targets. Replaced with a check to validate the ObjectClass of an AD object found by Get-ADComputer is "computer" 